### PR TITLE
feat(wrapped-ether): update symbol from wETH to WETH

### DIFF
--- a/tokenlist.json
+++ b/tokenlist.json
@@ -40,7 +40,7 @@
     },
     {
       "name": "Vault Bridge ETH",
-      "symbol": "wETH",
+      "symbol": "WETH",
       "decimals": 18,
       "chainId": 747474,
       "address": "0xEE7D8BCFb72bC1880D0Cf19822eB0A2e6577aB62",

--- a/tokenlist.json
+++ b/tokenlist.json
@@ -10,7 +10,7 @@
   "version": {
     "major": 1,
     "minor": 1,
-    "patch": 11
+    "patch": 12
   },
   "tokens": [
     {


### PR DESCRIPTION
For consistency, as this is how it is displayed in a lot of other apps.
ex Etherscan:
<img width="457" height="181" alt="image" src="https://github.com/user-attachments/assets/bd156712-ee8c-4d49-b264-7fee219a2b59" />
