### PR TITLE
feat: add missing Sushi/vKAT gauge tokens

### DIFF
--- a/tokenlist.json
+++ b/tokenlist.json
@@ -9,8 +9,8 @@
   ],
   "version": {
     "major": 1,
-    "minor": 1,
-    "patch": 12
+    "minor": 2,
+    "patch": 0
   },
   "tokens": [
     {
@@ -281,7 +281,10 @@
       "originTokenAddress": "0x6bef15d938d4e72056ac92ea4bdd0d76b1c4ad29",
       "chainId": 747474,
       "address": "0xb244Add9FE6cB17558221e4Dfea960e680CCD29b",
-      "logoURI": "https://assets.katana.network/icons/prove.svg"
+      "logoURI": "https://assets.katana.network/icons/prove.svg",
+      "tags": [
+        "priority"
+      ]
     },
     {
       "name": "Bridge-wrapped ChainLink Token",
@@ -291,7 +294,10 @@
       "originTokenAddress": "0x514910771af9ca656af840dff83e8264ecf986ca",
       "chainId": 747474,
       "address": "0x4570545894be2140708048781276bbd0fae15514",
-      "logoURI": "https://assets.katana.network/icons/link.svg"
+      "logoURI": "https://assets.katana.network/icons/link.svg",
+      "tags": [
+        "priority"
+      ]
     },
     {
       "name": "Bridge-wrapped Pepe",
@@ -301,7 +307,122 @@
       "originTokenAddress": "0x6982508145454ce325ddbe47a25d4ec3d2311933",
       "chainId": 747474,
       "address": "0x7fa65cb97efb27ad709b29856aafcbd51a294237",
-      "logoURI": "https://assets.katana.network/icons/pepe.svg"
+      "logoURI": "https://assets.katana.network/icons/pepe.svg",
+      "tags": [
+        "priority"
+      ]
+    },
+    {
+      "name": "Frax USD",
+      "symbol": "frxUSD",
+      "decimals": 18,
+      "chainId": 747474,
+      "address": "0x80eede496655fb9047dd39d9f418d5483ed600df",
+      "originTokenAddress": "0xCAcd6fd266aF91b8AeD52aCCc382b4e165586E29",
+      "originChainId": 1,
+      "logoURI": "https://assets.katana.network/icons/frxusd.svg",
+      "tags": [
+        "priority"
+      ]
+    },
+    {
+      "name": "Staked Frax USD",
+      "symbol": "sfrxUSD",
+      "decimals": 18,
+      "chainId": 747474,
+      "address": "0x5bff88ca1442c2496f7e475e9e7786383bc070c0",
+      "originTokenAddress": "0xcf62f905562626cfcdd2261162a51fd02fc9c5b6",
+      "originChainId": 1,
+      "logoURI": "https://assets.katana.network/icons/sfrxusd.svg",
+      "tags": [
+        "priority"
+      ]
+    },
+    {
+      "name": "KAI",
+      "symbol": "KAI",
+      "decimals": 18,
+      "chainId": 747474,
+      "address": "0x0f26bbb8962d73bc891327f14db5162d5279899f",
+      "originTokenAddress": "0x0000000000000000000000000000000000000000",
+      "logoURI": "https://assets.katana.network/icons/kai.svg",
+      "tags": [
+        "priority"
+      ]
+    },
+    {
+      "name": "dTRINITY USD",
+      "symbol": "dUSD",
+      "decimals": 18,
+      "chainId": 747474,
+      "address": "0xca52d08737e6af8763a2bf6034b3b03868f24dda",
+      "originTokenAddress": "0x0000000000000000000000000000000000000000",
+      "logoURI": "https://assets.katana.network/icons/dusd.svg",
+      "tags": [
+        "priority"
+      ]
+    },
+    {
+      "name": "Staked YUSD",
+      "symbol": "sYUSD",
+      "decimals": 18,
+      "chainId": 747474,
+      "address": "0xfcef626de4a0175ac962dd43eb0a002819faaefe",
+      "originTokenAddress": "0xfe0ccc9942e98c963fe6b4e5194eb6e3baa4cb64",
+      "originChainId": 1,
+      "logoURI": "https://assets.katana.network/icons/syusd.svg",
+      "tags": [
+        "priority"
+      ]
+    },
+    {
+      "name": "Kitsu",
+      "symbol": "KITSU",
+      "decimals": 18,
+      "chainId": 747474,
+      "address": "0xfba805659e5050544e185cccdf592fd77f8c7210",
+      "originTokenAddress": "0x0000000000000000000000000000000000000000",
+      "logoURI": "https://assets.katana.network/icons/kitsu.svg",
+      "tags": [
+        "priority"
+      ]
+    },
+    {
+      "name": "BUSHIDO",
+      "symbol": "BUSHIDO",
+      "decimals": 18,
+      "chainId": 747474,
+      "address": "0xa600a613c967b9edf2b6019ea300abc738f88637",
+      "originTokenAddress": "0x0000000000000000000000000000000000000000",
+      "logoURI": "https://assets.katana.network/icons/bushido.svg",
+      "tags": [
+        "priority"
+      ]
+    },
+    {
+      "name": "Unity",
+      "symbol": "UTY",
+      "decimals": 18,
+      "chainId": 747474,
+      "address": "0x2A66d51407b84b82b5AFF3DeC4D49f72CBCD322a",
+      "originTokenAddress": "0x0000000000000000000000000000000000000000",
+      "logoURI": "https://assets.katana.network/icons/uty.svg",
+      "tags": [
+        "priority"
+      ]
+    },
+    {
+      "name": "Woofy",
+      "symbol": "WOOFY",
+      "decimals": 12,
+      "chainId": 747474,
+      "address": "0x0eF68c1aB3C83CF11f9546FaBA385E8a1bd38d74",
+      "originTokenAddress": "0xd0660cd418a64a1d44e9214ad8e459324d8157f1",
+      "originChainId": 1,
+      "logoURI": "https://assets.katana.network/icons/woofy.svg",
+      "tags": [
+        "priority"
+      ]
     }
   ]
 }

--- a/tokenlist.json
+++ b/tokenlist.json
@@ -10,7 +10,7 @@
   "version": {
     "major": 1,
     "minor": 2,
-    "patch": 0
+    "patch": 1
   },
   "tokens": [
     {
@@ -420,6 +420,18 @@
       "originTokenAddress": "0xd0660cd418a64a1d44e9214ad8e459324d8157f1",
       "originChainId": 1,
       "logoURI": "https://assets.katana.network/icons/woofy.svg",
+      "tags": [
+        "priority"
+      ]
+    },
+    {
+      "name": "Auto-Staked KAT",
+      "symbol": "avKAT",
+      "decimals": 18,
+      "chainId": 747474,
+      "address": "0x7231dbaCdFc968E07656D12389AB20De82FbfCeB",
+      "originTokenAddress": "0x0000000000000000000000000000000000000000",
+      "logoURI": "https://assets.katana.network/icons/avkat.png",
       "tags": [
         "priority"
       ]

--- a/tokenlist.json
+++ b/tokenlist.json
@@ -320,7 +320,7 @@
       "address": "0x80eede496655fb9047dd39d9f418d5483ed600df",
       "originTokenAddress": "0xCAcd6fd266aF91b8AeD52aCCc382b4e165586E29",
       "originChainId": 1,
-      "logoURI": "https://assets.katana.network/icons/frxusd.svg",
+      "logoURI": "https://assets.katana.network/icons/frxusd.png",
       "tags": [
         "priority"
       ]
@@ -333,7 +333,7 @@
       "address": "0x5bff88ca1442c2496f7e475e9e7786383bc070c0",
       "originTokenAddress": "0xcf62f905562626cfcdd2261162a51fd02fc9c5b6",
       "originChainId": 1,
-      "logoURI": "https://assets.katana.network/icons/sfrxusd.svg",
+      "logoURI": "https://assets.katana.network/icons/sfrxusd.png",
       "tags": [
         "priority"
       ]
@@ -345,7 +345,7 @@
       "chainId": 747474,
       "address": "0x0f26bbb8962d73bc891327f14db5162d5279899f",
       "originTokenAddress": "0x0000000000000000000000000000000000000000",
-      "logoURI": "https://assets.katana.network/icons/kai.svg",
+      "logoURI": "https://assets.katana.network/icons/kai.png",
       "tags": [
         "priority"
       ]
@@ -357,7 +357,7 @@
       "chainId": 747474,
       "address": "0xca52d08737e6af8763a2bf6034b3b03868f24dda",
       "originTokenAddress": "0x0000000000000000000000000000000000000000",
-      "logoURI": "https://assets.katana.network/icons/dusd.svg",
+      "logoURI": "https://assets.katana.network/icons/dusd.png",
       "tags": [
         "priority"
       ]
@@ -370,7 +370,7 @@
       "address": "0xfcef626de4a0175ac962dd43eb0a002819faaefe",
       "originTokenAddress": "0xfe0ccc9942e98c963fe6b4e5194eb6e3baa4cb64",
       "originChainId": 1,
-      "logoURI": "https://assets.katana.network/icons/syusd.svg",
+      "logoURI": "https://assets.katana.network/icons/syusd.png",
       "tags": [
         "priority"
       ]
@@ -382,7 +382,7 @@
       "chainId": 747474,
       "address": "0xfba805659e5050544e185cccdf592fd77f8c7210",
       "originTokenAddress": "0x0000000000000000000000000000000000000000",
-      "logoURI": "https://assets.katana.network/icons/kitsu.svg",
+      "logoURI": "https://assets.katana.network/icons/kitsu.jpg",
       "tags": [
         "priority"
       ]
@@ -394,7 +394,7 @@
       "chainId": 747474,
       "address": "0xa600a613c967b9edf2b6019ea300abc738f88637",
       "originTokenAddress": "0x0000000000000000000000000000000000000000",
-      "logoURI": "https://assets.katana.network/icons/bushido.svg",
+      "logoURI": "https://assets.katana.network/icons/bushido.png",
       "tags": [
         "priority"
       ]
@@ -406,7 +406,7 @@
       "chainId": 747474,
       "address": "0x2A66d51407b84b82b5AFF3DeC4D49f72CBCD322a",
       "originTokenAddress": "0x0000000000000000000000000000000000000000",
-      "logoURI": "https://assets.katana.network/icons/uty.svg",
+      "logoURI": "https://assets.katana.network/icons/uty.png",
       "tags": [
         "priority"
       ]


### PR DESCRIPTION
## Summary

Adds 12 tokens that are live on Sushi / whitelisted for vKAT gauges but weren't showing in the app:

### Priority tag added (already in tokenlist)
- **PEPE** - Bridge-wrapped Pepe
- **LINK** - Bridge-wrapped ChainLink Token
- **PROVE** - Bridge-wrapped Succinct

### New tokens added
| Token | Symbol | Address | Decimals | Origin |
|-------|--------|---------|----------|--------|
| Frax USD | frxUSD | `0x80eede496655fb9047dd39d9f418d5483ed600df` | 18 | Ethereum |
| Staked Frax USD | sfrxUSD | `0x5bff88ca1442c2496f7e475e9e7786383bc070c0` | 18 | Ethereum |
| KAI | KAI | `0x0f26bbb8962d73bc891327f14db5162d5279899f` | 18 | Native |
| dTRINITY USD | dUSD | `0xca52d08737e6af8763a2bf6034b3b03868f24dda` | 18 | Native |
| Staked YUSD | sYUSD | `0xfcef626de4a0175ac962dd43eb0a002819faaefe` | 18 | Ethereum |
| Kitsu | KITSU | `0xfba805659e5050544e185cccdf592fd77f8c7210` | 18 | Native |
| BUSHIDO | BUSHIDO | `0xa600a613c967b9edf2b6019ea300abc738f88637` | 18 | Native |
| Unity | UTY | `0x2A66d51407b84b82b5AFF3DeC4D49f72CBCD322a` | 18 | Native |
| Woofy | WOOFY | `0x0eF68c1aB3C83CF11f9546FaBA385E8a1bd38d74` | 12 | Ethereum |

All tokens added with `priority` tag. Version bumped to 1.2.0.

## Action Required

Icons need to be uploaded to `assets.katana.network/icons/` for:

| File | Format | Note |
|------|--------|------|
| `frxusd.png` | PNG | |
| `sfrxusd.png` | PNG | |
| `kai.png` | PNG | Low-res (64px from Sushi CDN) — need high-res from KAI team |
| `dusd.png` | PNG | Low-res (64px from Sushi CDN) — need high-res from dTRINITY team |
| `syusd.png` | PNG | |
| `kitsu.jpg` | JPG | |
| `bushido.png` | PNG | |
| `uty.png` | PNG | |
| `woofy.svg` | SVG | |

## Verification

- All contract addresses verified on [KatanaScan](https://katanascan.com)
- Origin chain addresses verified on Etherscan where applicable
- JSON validated (33 tokens total, no duplicates)